### PR TITLE
Explicitly added libevent in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache --update \
     sudo \
     aria2 \
     util-linux \
+    libevent \
     chromium \
     chromium-chromedriver \
     jpeg-dev \


### PR DESCRIPTION
Chromium and ChromeDriver needs it.
Fixes the error : https://del.dog/aqehumugun

[UNTESTED, coz dead project.]